### PR TITLE
Update to 1.19.1 release

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ repositories {
 }
 
 dependencies {
-    paperDevBundle("1.19.1-rc2-R0.1-SNAPSHOT")
+    paperDevBundle("1.19.1-R0.1-SNAPSHOT")
 }
 
 tasks {


### PR DESCRIPTION
Updates the gradle build settings to use Paper 1.19.1, before it was refusing to compile